### PR TITLE
Stop dockerhub token in being required

### DIFF
--- a/.github/workflows/docker-release-workflow.yaml
+++ b/.github/workflows/docker-release-workflow.yaml
@@ -27,7 +27,6 @@ on:
         type: string
     secrets:
       DOCKERHUB_TOKEN:
-        required: true
 
 jobs:
   release-docker:


### PR DESCRIPTION
## Purpose

dockerhub token should not be required as we don't need it when we push to ECR

## Changes

Remove required field on DOCKERHUB_TOKEN secret

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.

## CLA acceptance

_Remove if not applicable.

By submitting the contribution I accept the terms and conditions of the
Contributor License Agreement v1.0
- link: https://developers.concordium.com/CLAs/Contributor-License-Agreement-v1.0.pdf

- [x] I accept the above linked CLA.
